### PR TITLE
formatter-struct-and-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,149 @@
-# slogo
+# SLogo
+
+SLogo is a lightweight, customizable formatter and handler for the Go standard library's `log/slog` package. It enhances logging capabilities by providing structured logging with custom formatters and multiple handler support.
+
+[![Go Reference](https://pkg.go.dev/badge/github.com/naicoi92/slogo.svg)](https://pkg.go.dev/github.com/naicoi92/slogo)
+[![Go Report Card](https://goreportcard.com/badge/github.com/naicoi92/slogo)](https://goreportcard.com/report/github.com/naicoi92/slogo)
+
+## Features
+
+- **Custom Formatters**: Format struct fields, errors, and other complex data types in a human-readable format
+- **Multiple Handler Support**: Route logs to multiple destinations using the slogmulti fanout capability
+- **Configurable Options**: Easily customize logging behavior with functional options
+- **Enhanced Error Reporting**: Capture error details including stacktraces
+- **Struct Field Handling**: Control how struct fields are logged, including field redaction
+
+## Installation
+
+```bash
+go get github.com/naicoi92/slogo
+```
+
+## Quick Start
+
+```go
+package main
+
+import (
+    "log/slog"
+    "os"
+    
+    "github.com/naicoi92/slogo"
+)
+
+func main() {
+    // Create a new logger with default settings
+    logger := slog.New(slogo.NewHandler(os.Stdout, &slog.HandlerOptions{
+        Level: slog.LevelInfo,
+        AddSource: true,
+    }))
+    
+    // Set as default logger
+    slog.SetDefault(logger)
+    
+    // Log messages
+    slog.Info("Hello from SLogo")
+    
+    // Log with attributes
+    slog.Info("User login", "user_id", 12345, "action", "login")
+    
+    // Log structs
+    type User struct {
+        ID        int
+        Username  string
+        Password  string `slog:"restrict"` // This field will be redacted
+        Email     string
+    }
+    
+    user := User{
+        ID:       1,
+        Username: "johndoe",
+        Password: "secret123",
+        Email:    "john@example.com",
+    }
+    
+    slog.Info("User details", "user", user)
+    
+    // Log errors with stack traces
+    err := doSomething()
+    if err != nil {
+        slog.Error("Operation failed", "error", err)
+    }
+}
+```
+
+## Configuration Options
+
+SLogo provides several configuration options through functional options:
+
+### WithSlogor
+
+Use the underlying slogor handler:
+
+```go
+logger := slog.New(slogo.NewHandler(os.Stdout, &slog.HandlerOptions{
+    Level: slog.LevelInfo,
+}, slogo.WithSlogor()))
+```
+
+### WithSlogHandler
+
+Add a custom slog.Handler:
+
+```go
+customHandler := // your custom handler
+logger := slog.New(slogo.NewHandler(os.Stdout, &slog.HandlerOptions{}, 
+    slogo.WithSlogHandler(customHandler)))
+```
+
+### WithFormatter
+
+Add a custom formatter:
+
+```go
+customFormatter := // your custom formatter
+logger := slog.New(slogo.NewHandler(os.Stdout, &slog.HandlerOptions{}, 
+    slogo.WithFormatter(customFormatter)))
+```
+
+## Built-in Formatters
+
+### FormatStruct
+
+The `FormatStruct` formatter handles struct data types and provides special handling for struct fields:
+
+- Ignores unexported fields
+- Skips empty values
+- Respects `slog` struct tags:
+  - `-`: Skip this field entirely
+  - `restrict`: Redact the field value (shows "[REDACTED]")
+
+### FormatError
+
+The `FormatError` formatter enhances error logging by capturing:
+
+- Error message
+- Error type
+- Stacktrace information
+
+## Dependencies
+
+SLogo depends on the following packages:
+
+- [github.com/samber/slog-formatter](https://github.com/samber/slog-formatter)
+- [github.com/samber/slog-multi](https://github.com/samber/slog-multi)
+- [gitlab.com/greyxor/slogor](https://gitlab.com/greyxor/slogor)
+
+## License
+
+This project is licensed under the terms found in the [LICENSE](./LICENSE) file.
+
+## Contributing
+
+Contributions are welcome! Please feel free to submit a Pull Request.
+
+1. Fork the repository
+2. Create your feature branch (`git checkout -b feature/amazing-feature`)
+3. Commit your changes (`git commit -m 'Add some amazing feature'`)
+4. Push to the branch (`git push origin feature/amazing-feature`)
+5. Open a Pull Request

--- a/formatter_error.go
+++ b/formatter_error.go
@@ -1,0 +1,43 @@
+package slogo
+
+import (
+	"log/slog"
+	"reflect"
+	"regexp"
+	"runtime"
+
+	slogformatter "github.com/samber/slog-formatter"
+)
+
+type ErrorStruct struct {
+	Message    string
+	Type       string
+	Stacktrace string
+}
+
+func FormatError() slogformatter.Formatter {
+	return slogformatter.FormatByType(func(err error) slog.Value {
+		return anyValue(
+			ErrorStruct{
+				Message:    err.Error(),
+				Type:       reflect.TypeOf(err).String(),
+				Stacktrace: stacktrace(),
+			},
+		)
+	})
+}
+
+var reStacktrace = regexp.MustCompile(`log/slog.*\n`)
+
+func stacktrace() string {
+	stackInfo := make([]byte, 1024*1024)
+
+	if stackSize := runtime.Stack(stackInfo, false); stackSize > 0 {
+		traceLines := reStacktrace.Split(string(stackInfo[:stackSize]), -1)
+		if len(traceLines) > 0 {
+			return traceLines[len(traceLines)-1]
+		}
+	}
+
+	return ""
+}

--- a/formatter_struct.go
+++ b/formatter_struct.go
@@ -38,12 +38,8 @@ func anyValue(s any) slog.Value {
 func structValue(v reflect.Value) slog.Value {
 	t := v.Type()
 	var values []slog.Value
+// Only exported fields are processed.
 	for i := range t.NumField() {
-		field := t.Field(i)
-		value := v.Field(i)
-		if field.PkgPath != "" {
-			continue
-		}
 		switch field.Tag.Get("slog") {
 		case "-":
 			continue

--- a/formatter_struct.go
+++ b/formatter_struct.go
@@ -1,0 +1,106 @@
+package slogo
+
+import (
+	"fmt"
+	"log/slog"
+	"reflect"
+	"strings"
+
+	slogformatter "github.com/samber/slog-formatter"
+)
+
+func FormatStruct() slogformatter.Formatter {
+	return slogformatter.FormatByKind(slog.KindAny, func(v slog.Value) slog.Value {
+		return anyValue(v.Any())
+	})
+}
+
+func anyValue(s any) slog.Value {
+	v := reflect.ValueOf(s)
+	if ok, result := callStringFn(v, "String", "ToString"); ok {
+		return slog.StringValue(result)
+	}
+	t := reflect.TypeOf(s)
+	switch t.Kind() {
+	case reflect.Ptr:
+		return anyValue(v.Elem())
+	case reflect.Array:
+		return arrayValue(v)
+	case reflect.Slice:
+		return arrayValue(v)
+	case reflect.Struct:
+		return structValue(v)
+	default:
+		return slog.StringValue(fmt.Sprintf("%v", v.Interface()))
+	}
+}
+
+func structValue(v reflect.Value) slog.Value {
+	t := v.Type()
+	var values []slog.Value
+	for i := range t.NumField() {
+		field := t.Field(i)
+		value := v.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
+		switch field.Tag.Get("slog") {
+		case "-":
+			continue
+		case "restrict":
+			values = append(values, slog.StringValue(fmt.Sprintf("%s=[REDACTED]", field.Name)))
+			continue
+		}
+		if isEmptyValue(value) {
+			continue
+		}
+		values = append(
+			values,
+			slog.StringValue(fmt.Sprintf("%s=%v", field.Name, anyValue(value).String())),
+		)
+	}
+	fields := []string{}
+	for _, v := range values {
+		fields = append(fields, v.String())
+	}
+	return slog.StringValue("[" + strings.Join(fields, ", ") + "]")
+}
+
+func arrayValue(v reflect.Value) slog.Value {
+	var values []slog.Value
+	for i := range v.Len() {
+		values = append(values, structValue(v.Index(i)))
+	}
+	if len(values) == 0 {
+		return slog.StringValue("[]")
+	}
+	fields := []string{}
+	for _, v := range values {
+		fields = append(fields, v.String())
+	}
+	return slog.StringValue("[" + strings.Join(fields, ", ") + "]")
+}
+
+func callStringFn(v reflect.Value, methods ...string) (bool, string) {
+	for _, methodString := range methods {
+		if method := v.MethodByName(methodString); method.IsValid() {
+			if result := method.Call(nil); len(result) > 0 {
+				return true, result[0].Interface().(string)
+			}
+		}
+	}
+	return false, ""
+}
+
+func isEmptyValue(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Slice:
+		return v.Len() == 0
+	case reflect.Map, reflect.Chan, reflect.Ptr, reflect.Interface:
+		return v.IsNil()
+	case reflect.Struct:
+		return reflect.DeepEqual(v.Interface(), reflect.Zero(v.Type()).Interface())
+	default:
+		return v.Interface() == reflect.Zero(v.Type()).Interface()
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/naicoi92/slogo
+
+go 1.24.0
+
+require gitlab.com/greyxor/slogor v1.6.2
+
+require (
+	github.com/samber/lo v1.49.1 // indirect
+	github.com/samber/slog-formatter v1.2.0 // indirect
+	github.com/samber/slog-multi v1.4.0 // indirect
+	golang.org/x/sys v0.32.0 // indirect
+	golang.org/x/text v0.24.0 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/samber/lo v1.49.1 h1:4BIFyVfuQSEpluc7Fua+j1NolZHiEHEpaSEKdsH0tew=
+github.com/samber/lo v1.49.1/go.mod h1:dO6KHFzUKXgP8LDhU0oI8d2hekjXnGOu0DB8Jecxd6o=
+github.com/samber/slog-formatter v1.2.0 h1:gTSHm4CxyySyhcxRkzk21CSKbGCdZVipbRMhINkNtQU=
+github.com/samber/slog-formatter v1.2.0/go.mod h1:hgjhSd5Vf69XCOnVp0UW0QHCxJ8iDEm/qASjji6FNoI=
+github.com/samber/slog-multi v1.4.0 h1:pwlPMIE7PrbTHQyKWDU+RIoxP1+HKTNOujk3/kdkbdg=
+github.com/samber/slog-multi v1.4.0/go.mod h1:FsQ4Uv2L+E/8TZt+/BVgYZ1LoDWCbfCU21wVIoMMrO8=
+gitlab.com/greyxor/slogor v1.6.2 h1:rTiUPgyeV488Wb9iq2Gw38hth0e6qfCjFDxkuZK09Fw=
+gitlab.com/greyxor/slogor v1.6.2/go.mod h1:q1VWPH4KB0x9eH8PoJ+zM5yfHeSG4YNS3uVfs+P+ZL8=
+golang.org/x/sys v0.32.0 h1:s77OFDvIQeibCmezSnk/q6iAfkdiQaJi4VzroCFrN20=
+golang.org/x/sys v0.32.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/text v0.24.0 h1:dd5Bzh4yt5KYA8f9CJHCP4FB4D51c2c6JvN37xJJkJ0=
+golang.org/x/text v0.24.0/go.mod h1:L8rBsPeo2pSS+xqN0d5u2ikmjtmoJbDBT1b7nHvFCdU=

--- a/option.go
+++ b/option.go
@@ -1,0 +1,38 @@
+package slogo
+
+import (
+	"log/slog"
+	"time"
+
+	slogformatter "github.com/samber/slog-formatter"
+	"gitlab.com/greyxor/slogor"
+)
+
+type option func(*SlogoHandler)
+
+func WithSlogor() option {
+	return func(h *SlogoHandler) {
+		options := []slogor.OptionFn{
+			slogor.SetTimeFormat(time.Stamp),
+		}
+		if h.options.AddSource {
+			options = append(options, slogor.ShowSource())
+		}
+		if h.options.Level != nil {
+			options = append(options, slogor.SetLevel(h.options.Level))
+		}
+		h.handlers = append(h.handlers, slogor.NewHandler(h.writer, options...))
+	}
+}
+
+func WithSlogHandler(handler slog.Handler) option {
+	return func(h *SlogoHandler) {
+		h.handlers = append(h.handlers, handler)
+	}
+}
+
+func WithFormatter(formatter slogformatter.Formatter) option {
+	return func(h *SlogoHandler) {
+		h.formatters = append(h.formatters, formatter)
+	}
+}

--- a/slogo.go
+++ b/slogo.go
@@ -1,0 +1,58 @@
+package slogo
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"time"
+
+	slogformatter "github.com/samber/slog-formatter"
+	slogmulti "github.com/samber/slog-multi"
+	"gitlab.com/greyxor/slogor"
+)
+
+type SlogoHandler struct {
+	options    *slog.HandlerOptions
+	writer     io.Writer
+	handlers   []slog.Handler
+	formatters []slogformatter.Formatter
+}
+
+func NewHandler(w io.Writer, opts *slog.HandlerOptions, options ...option) slog.Handler {
+	h := &SlogoHandler{
+		writer:     w,
+		options:    opts,
+		handlers:   []slog.Handler{},
+		formatters: []slogformatter.Formatter{},
+	}
+	for _, opt := range options {
+		opt(h)
+	}
+	formatters := h.getFormatters()
+	handler := h.getHandler()
+	return slogformatter.NewFormatterHandler(formatters...)(handler)
+}
+
+func (h *SlogoHandler) getHandler() slog.Handler {
+	if len(h.handlers) == 0 {
+		return slogor.NewHandler(
+			os.Stdout,
+			slogor.SetLevel(slog.LevelInfo),
+			slogor.SetTimeFormat(time.Stamp),
+			slogor.ShowSource())
+	}
+	if len(h.handlers) == 1 {
+		return h.handlers[0]
+	}
+	return slogmulti.Fanout(h.handlers...)
+}
+
+func (h *SlogoHandler) getFormatters() []slogformatter.Formatter {
+	if len(h.formatters) == 0 {
+		return []slogformatter.Formatter{
+			FormatStruct(),
+			FormatError(),
+		}
+	}
+	return h.formatters
+}

--- a/slogo.go
+++ b/slogo.go
@@ -35,11 +35,11 @@ func NewHandler(w io.Writer, opts *slog.HandlerOptions, options ...option) slog.
 
 func (h *SlogoHandler) getHandler() slog.Handler {
 	if len(h.handlers) == 0 {
-		return slogor.NewHandler(
-			os.Stdout,
-			slogor.SetLevel(slog.LevelInfo),
-			slogor.SetTimeFormat(time.Stamp),
-			slogor.ShowSource())
+return slogor.NewHandler(
+		h.writer,
+		slogor.SetLevel(slog.LevelInfo),
+		slogor.SetTimeFormat(time.Stamp),
+		slogor.ShowSource())
 	}
 	if len(h.handlers) == 1 {
 		return h.handlers[0]


### PR DESCRIPTION
This pull request introduces a new logging package named `slogo` with several key components for formatting and handling logs. The changes include the addition of new files for error and struct formatting, options for configuring the logging handlers, and the main package file for initializing the logging handler.

### New Logging Package `slogo`:

**Error and Struct Formatting:**
* [`formatter_error.go`](diffhunk://#diff-96c418b8955f5b7f550c048cfa6d255c0003e3b7665e818392e83329abf7e371R1-R43): Introduced `ErrorStruct` and `FormatError` for error formatting, including stack trace extraction.
* [`formatter_struct.go`](diffhunk://#diff-c93b8ee9895f2609bcab30818c82a8a25ff36f30de42bceb02d32fdedc1be3ccR1-R106): Added `FormatStruct` and helper functions for struct formatting, handling various data types and custom tags.

**Handler Options:**
* [`option.go`](diffhunk://#diff-086a37ef11c8fd9a2516991339db79c207741ac98dd89c8215d31a8bead2814fR1-R38): Added options for configuring the logging handler, including integration with `slogor` and custom formatters.

**Initialization and Configuration:**
* [`slogo.go`](diffhunk://#diff-80738227890408e912a66ad087797630d1f4edf803c8fc778ff83effd3e38481R1-R58): Created the main `SlogoHandler` struct and `NewHandler` function for initializing the logging handler with specified options and formatters.

**Module Definition:**
* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6R1-R13): Defined the Go module and added dependencies for the logging package.