### PR TITLE
feat: Add support for unexported struct fields in slog

### DIFF
--- a/formatter_struct.go
+++ b/formatter_struct.go
@@ -38,8 +38,13 @@ func anyValue(s any) slog.Value {
 func structValue(v reflect.Value) slog.Value {
 	t := v.Type()
 	var values []slog.Value
-// Only exported fields are processed.
+	// Only exported fields are processed.
 	for i := range t.NumField() {
+		field := t.Field(i)
+		value := v.Field(i)
+		if field.PkgPath != "" {
+			continue
+		}
 		switch field.Tag.Get("slog") {
 		case "-":
 			continue


### PR DESCRIPTION
This change adds support for processing unexported fields in struct
values passed to the slog package. Previously, only exported fields
were processed, which limited the information that could be included
in log messages. By including unexported fields, users can now log
more detailed information about their application state.