### PR TITLE
feat(formatter): improve error formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# SLogo
+# slogo
 
-SLogo is a lightweight, customizable formatter and handler for the Go standard library's `log/slog` package. It enhances logging capabilities by providing structured logging with custom formatters and multiple handler support.
+slogo is a lightweight, customizable formatter and handler for the Go standard library's `log/slog` package. It enhances logging capabilities by providing structured logging with custom formatters and multiple handler support.
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/naicoi92/slogo.svg)](https://pkg.go.dev/github.com/naicoi92/slogo)
 [![Go Report Card](https://goreportcard.com/badge/github.com/naicoi92/slogo)](https://goreportcard.com/report/github.com/naicoi92/slogo)

--- a/example/main.go
+++ b/example/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"errors"
+	"log/slog"
+	"net/netip"
+	"os"
+
+	"github.com/naicoi92/slogo"
+)
+
+func main() {
+	// Create a new logger with default settings
+	logger := slog.New(
+		slogo.NewHandler(
+			os.Stdout,
+			&slog.HandlerOptions{
+				Level:     slog.LevelInfo,
+				AddSource: true,
+			},
+		),
+	)
+
+	// Set as default logger
+	slog.SetDefault(logger)
+
+	// Log messages
+	slog.Info("Hello from SLogo")
+
+	// Log with attributes
+	slog.Info("User login", "user_id", 12345, "action", "login")
+
+	// Log structs
+	type User struct {
+		ID        int        `json:"id"`
+		Username  string     `json:"username"`
+		Password  string     `json:"password"   slog:"restrict"` // This field will be redacted
+		Email     string     `json:"email"`
+		IpAddress netip.Addr `json:"ip_address"`
+		Members   []*User    `json:"members"`
+	}
+	ip, err := netip.ParseAddr("10.0.0.1")
+	if err != nil {
+		slog.Error("Failed to parse IP address", "error", err)
+	}
+	user := User{
+		ID:        1,
+		Username:  "johndoe",
+		Password:  "secret123",
+		Email:     "john@example.com",
+		IpAddress: ip,
+		Members: []*User{
+			{
+				ID:       2,
+				Username: "janedoe",
+			},
+			{
+				ID:        3,
+				Username:  "alice",
+				IpAddress: ip,
+			},
+		},
+	}
+
+	slog.Info("User details", "user", user)
+
+	// Log errors with stack traces
+	if err := errors.New("an example error"); err != nil {
+		slog.Error("Operation failed", "error", err)
+	}
+}

--- a/formatter_error.go
+++ b/formatter_error.go
@@ -13,7 +13,7 @@ type ErrorStruct struct {
 }
 
 func FormatError() slogformatter.Formatter {
-	return slogformatter.FormatByType(func(err error) slog.Value {
+	return slogformatter.FormatByType[error](func(err error) slog.Value {
 		e := ErrorStruct{
 			Message: err.Error(),
 			Type:    reflect.TypeOf(err).String(),

--- a/formatter_error.go
+++ b/formatter_error.go
@@ -3,41 +3,21 @@ package slogo
 import (
 	"log/slog"
 	"reflect"
-	"regexp"
-	"runtime"
 
 	slogformatter "github.com/samber/slog-formatter"
 )
 
 type ErrorStruct struct {
-	Message    string
-	Type       string
-	Stacktrace string
+	Message string
+	Type    string
 }
 
 func FormatError() slogformatter.Formatter {
 	return slogformatter.FormatByType(func(err error) slog.Value {
-		return anyValue(
-			ErrorStruct{
-				Message:    err.Error(),
-				Type:       reflect.TypeOf(err).String(),
-				Stacktrace: stacktrace(),
-			},
-		)
-	})
-}
-
-var reStacktrace = regexp.MustCompile(`log/slog.*\n`)
-
-func stacktrace() string {
-	stackInfo := make([]byte, 1024*1024)
-
-	if stackSize := runtime.Stack(stackInfo, false); stackSize > 0 {
-		traceLines := reStacktrace.Split(string(stackInfo[:stackSize]), -1)
-		if len(traceLines) > 0 {
-			return traceLines[len(traceLines)-1]
+		e := ErrorStruct{
+			Message: err.Error(),
+			Type:    reflect.TypeOf(err).String(),
 		}
-	}
-
-	return ""
+		return anyValue(e)
+	})
 }

--- a/formatter_struct.go
+++ b/formatter_struct.go
@@ -16,32 +16,36 @@ func FormatStruct() slogformatter.Formatter {
 }
 
 func anyValue(s any) slog.Value {
-	v := reflect.ValueOf(s)
-	if ok, result := callStringFn(v, "String", "ToString"); ok {
-		return slog.StringValue(result)
-	}
 	t := reflect.TypeOf(s)
+	v := reflect.ValueOf(s)
 	switch t.Kind() {
 	case reflect.Ptr:
-		return anyValue(v.Elem())
+		return anyValue(v.Elem().Interface())
 	case reflect.Array:
 		return arrayValue(v)
 	case reflect.Slice:
 		return arrayValue(v)
 	case reflect.Struct:
-		return structValue(v)
+		return structValue(v.Interface())
 	default:
-		return slog.StringValue(fmt.Sprintf("%v", v.Interface()))
+		return slog.AnyValue(v)
 	}
 }
 
-func structValue(v reflect.Value) slog.Value {
-	t := v.Type()
+func structValue(s any) slog.Value {
+	t := reflect.TypeOf(s)
+	v := reflect.ValueOf(s)
+	if ok, result := callStringFn(v, "String", "ToString"); ok {
+		return slog.StringValue(result)
+	}
 	var values []slog.Value
-	// Only exported fields are processed.
 	for i := range t.NumField() {
 		field := t.Field(i)
 		value := v.Field(i)
+		fieldName := field.Name
+		if field.Tag.Get("json") != "" {
+			fieldName = field.Tag.Get("json")
+		}
 		if field.PkgPath != "" {
 			continue
 		}
@@ -49,15 +53,28 @@ func structValue(v reflect.Value) slog.Value {
 		case "-":
 			continue
 		case "restrict":
-			values = append(values, slog.StringValue(fmt.Sprintf("%s=[REDACTED]", field.Name)))
+			values = append(values, slog.StringValue(fmt.Sprintf("%s=[REDACTED]", fieldName)))
 			continue
 		}
 		if isEmptyValue(value) {
 			continue
 		}
+		av := slog.StringValue(fmt.Sprintf("%v", value))
+		switch value.Kind() {
+		case reflect.Ptr:
+			av = anyValue(value.Elem().Interface())
+		case reflect.Array:
+			av = arrayValue(value)
+		case reflect.Slice:
+			av = arrayValue(value)
+		case reflect.Struct:
+			av = structValue(value.Interface())
+		}
 		values = append(
 			values,
-			slog.StringValue(fmt.Sprintf("%s=%v", field.Name, anyValue(value).String())),
+			slog.StringValue(
+				fmt.Sprintf("%s=%s", fieldName, av.String()),
+			),
 		)
 	}
 	fields := []string{}
@@ -70,7 +87,7 @@ func structValue(v reflect.Value) slog.Value {
 func arrayValue(v reflect.Value) slog.Value {
 	var values []slog.Value
 	for i := range v.Len() {
-		values = append(values, structValue(v.Index(i)))
+		values = append(values, anyValue(v.Index(i).Interface()))
 	}
 	if len(values) == 0 {
 		return slog.StringValue("[]")

--- a/formatter_struct.go
+++ b/formatter_struct.go
@@ -47,6 +47,7 @@ func structValue(s any) slog.Value {
 			fieldName = field.Tag.Get("json")
 		}
 		if field.PkgPath != "" {
+			values = append(values, slog.StringValue(fmt.Sprintf("%s=%v", fieldName, value)))
 			continue
 		}
 		switch field.Tag.Get("slog") {

--- a/slogo.go
+++ b/slogo.go
@@ -49,8 +49,8 @@ func (h *SlogoHandler) getHandler() slog.Handler {
 func (h *SlogoHandler) getFormatters() []slogformatter.Formatter {
 	if len(h.formatters) == 0 {
 		return []slogformatter.Formatter{
-			FormatStruct(),
 			FormatError(),
+			FormatStruct(),
 		}
 	}
 	return h.formatters


### PR DESCRIPTION
The changes in this commit focus on improving the error formatting in the `slogo` package. The main changes are:

1. Simplify the `ErrorStruct` by removing the `Stacktrace` field, as the stacktrace information is not necessary for most use cases.
2. Refactor the `FormatError` function to use the simplified `ErrorStruct`.
3. Improve the `anyValue` function to handle different types of values more efficiently, including pointers, arrays, slices, and structs.
4. Enhance the `structValue` function to use the `json` tag for field names and handle empty values more gracefully.
5. Update the `slogo.go` file to prioritize the `FormatError` formatter over the `FormatStruct` formatter.

These changes aim to provide a more concise and robust error formatting experience for the `slogo` package users.