### PR TITLE
feat(main): Add custom error handling

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -68,4 +68,9 @@ func main() {
 	if err := errors.New("an example error"); err != nil {
 		slog.Error("Operation failed", "error", err)
 	}
+	CustomError := errors.New("custom error")
+
+	if err := CustomError; err != nil {
+		slog.Error("Operation failed", "error", err)
+	}
 }

--- a/formatter_error.go
+++ b/formatter_error.go
@@ -8,15 +8,15 @@ import (
 )
 
 type ErrorStruct struct {
-	Message string
 	Type    string
+	Message string
 }
 
 func FormatError() slogformatter.Formatter {
 	return slogformatter.FormatByType[error](func(err error) slog.Value {
 		e := ErrorStruct{
-			Message: err.Error(),
 			Type:    reflect.TypeOf(err).String(),
+			Message: err.Error(),
 		}
 		return anyValue(e)
 	})

--- a/option.go
+++ b/option.go
@@ -8,9 +8,9 @@ import (
 	"gitlab.com/greyxor/slogor"
 )
 
-type option func(*SlogoHandler)
+type Option func(*SlogoHandler)
 
-func WithSlogor() option {
+func WithSlogor() Option {
 	return func(h *SlogoHandler) {
 		options := []slogor.OptionFn{
 			slogor.SetTimeFormat(time.Stamp),
@@ -25,13 +25,13 @@ func WithSlogor() option {
 	}
 }
 
-func WithSlogHandler(handler slog.Handler) option {
+func WithSlogHandler(handler slog.Handler) Option {
 	return func(h *SlogoHandler) {
 		h.handlers = append(h.handlers, handler)
 	}
 }
 
-func WithFormatter(formatter slogformatter.Formatter) option {
+func WithFormatter(formatter slogformatter.Formatter) Option {
 	return func(h *SlogoHandler) {
 		h.formatters = append(h.formatters, formatter)
 	}


### PR DESCRIPTION
This change adds a custom error handling to the main function. A new
custom error is created and logged using the slog.Error function. This
change improves the error handling in the application and provides more
detailed information about the errors that occur.

feat(option): Rename option type to Option

This change renames the `option` type to `Option` in the `option.go`
file. This change makes the code more consistent and easier to
understand.

refactor(formatter_error): Reorder fields in ErrorStruct

This change reorders the fields in the `ErrorStruct` struct in the
`formatter_error.go` file. The `Type` field is now before the `Message`
field. This change makes the code more consistent and easier to
understand.